### PR TITLE
[Docs] Release notes and link to contribution docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ repository for more information.
 > Python test targets are currently unsupported in this mode. If
 > `OPENASSETIOTEST_ENABLE_PYTHON` is `ON` (default) then CMake will fail
 > to configure with an error.
+
+## Development notes
+
+This package follows the main
+[OpenAssetIO contribution process](https://github.com/OpenAssetIO/OpenAssetIO/blob/main/contributing/PROCESS.md).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,9 @@
+Release Notes
+=============
+
+vX.X.X
+--------------
+
+### New Features
+
+* Initial version testing OpenAssetIO 1.0.0-alpha.6.


### PR DESCRIPTION
Flesh out this project to conform to the style of other projects in the OpenAssetIO org, in preparation for a release. A release will give us a tag that can be used to link OpenAssetIO version to associated compatible OpenAssetIO-Test-CMake version.
