### PR TITLE
Only test minimal header set

### DIFF
--- a/src/test.core.c
+++ b/src/test.core.c
@@ -2,16 +2,9 @@
 // Copyright 2022 The Foundry Visionmongers Ltd
 #include <stdio.h>
 
-// Include all headers to test they are where we expect and can be
-// compiled.
 #include <openassetio/c/InfoDictionary.h>
 #include <openassetio/c/StringView.h>
 #include <openassetio/c/errors.h>
-#include <openassetio/c/hostApi/Manager.h>
-#include <openassetio/c/managerApi/CManagerInterface.h>
-#include <openassetio/c/managerApi/HostSession.h>
-#include <openassetio/c/managerApi/ManagerInterface.h>
-#include <openassetio/c/namespace.h>
 
 #define kStringBufferCapacity 500
 

--- a/src/test.core.cpp
+++ b/src/test.core.cpp
@@ -1,29 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 The Foundry Visionmongers Ltd
 
-// Include all headers to test they are where we expect and can be
-// compiled.
-#include <openassetio/errors.h>
-#include <openassetio/BatchElementError.hpp>
-#include <openassetio/Context.hpp>
-#include <openassetio/EntityReference.hpp>
-#include <openassetio/InfoDictionary.hpp>
 #include <openassetio/TraitsData.hpp>
-#include <openassetio/hostApi/HostInterface.hpp>
-#include <openassetio/hostApi/Manager.hpp>
-#include <openassetio/hostApi/ManagerFactory.hpp>
-#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
-#include <openassetio/log/ConsoleLogger.hpp>
-#include <openassetio/log/LoggerInterface.hpp>
-#include <openassetio/log/SeverityFilter.hpp>
-#include <openassetio/managerApi/Host.hpp>
-#include <openassetio/managerApi/HostSession.hpp>
-#include <openassetio/managerApi/ManagerInterface.hpp>
-#include <openassetio/managerApi/ManagerStateBase.hpp>
-#include <openassetio/trait/TraitBase.hpp>
-#include <openassetio/trait/collection.hpp>
-#include <openassetio/trait/property.hpp>
-#include <openassetio/typedefs.hpp>
 
 int main() {
   auto traits = openassetio::TraitsData::make();


### PR DESCRIPTION
To avoid churn in OpenAssetIO PRs, don't attempt to `#include` all possible headers. Such a test of the install-tree structure should be handled by the upstream project.