### PR TITLE
[Test] Remove speculative traits that got removed from mediacreation.

### DIFF
--- a/src/test.mediacreation.cpp
+++ b/src/test.mediacreation.cpp
@@ -6,16 +6,6 @@
 #include <openassetio/TraitsData.hpp>
 
 #include <openassetio_mediacreation/openassetio_mediacreation.hpp>
-#include <openassetio_mediacreation/traits/content.hpp>
-#include <openassetio_mediacreation/traits/content/LocatableContentTrait.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy/ManagedTrait.hpp>
-#include <openassetio_mediacreation/traits/managementPolicy/ResolvesFutureEntitiesTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline.hpp>
-#include <openassetio_mediacreation/traits/timeline/ClipTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline/TimelineTrait.hpp>
-#include <openassetio_mediacreation/traits/timeline/TrackTrait.hpp>
-#include <openassetio_mediacreation/traits/traits.hpp>
 
 int main() {
   auto trait = openassetio_mediacreation::traits::managementPolicy::ManagedTrait(


### PR DESCRIPTION
Using the same logic from https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/pull/44, only include the top level header, otherwise we'll have to react each time a new mediacreation trait is added