### PR TITLE
[CI] Pin actions/checkout in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[CI]"
+    ignore:
+      # TODO(DF): Remove once no longer stuck on ASWF CY22 Docker image
+      # for CI (causing nodejs glibc error).
+      - dependency-name: "actions/checkout"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The latest version of actions/checkout bumps its nodejs dependency to v20, which requires a newer glibc version than is available in the ASWF CY22 Docker image.

See errors in https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/pull/11

Ultimately we aim to use GitHub release artifacts (https://github.com/OpenAssetIO/OpenAssetIO/issues/1094), negating the need for Docker (i.e. for making a throwaway build of dependencies). So in the meantime, just ignore major version updates of actions/checkout.

This may also be solved by updating to the CY23 container - https://github.com/OpenAssetIO/OpenAssetIO/issues/984