### PR TITLE
[Build] Fix GCC C++ linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,10 @@ if (OPENASSETIOTEST_ENABLE_C)
     add_executable(test.c.core src/test.core.c)
     add_test(c.core test.c.core)
     target_link_libraries(test.c.core PRIVATE OpenAssetIO::openassetio-core-c)
+    # Must use C++ linker settings or the C++ standard library might not
+    # be linked. This is required since openassetio-core-c depends on
+    # openassetio-core, which is a C++ library.
+    set_target_properties(test.c.core PROPERTIES LINKER_LANGUAGE CXX)
     target_compile_features(test.c.core PRIVATE c_std_99)
     if (WIN32 AND DEFINED OpenAssetIO_BINARY_DIR)
         set_tests_properties(c.core PROPERTIES ENVIRONMENT "PATH=${OpenAssetIO_BINARY_DIR_NATIVE}")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,12 @@ v1.0.0-alpha.x
 * CI testing added to exercise convergent dependency acquisition modes.
 [#7](https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/pull/7)
 
+### Bug Fixes
+
+* Updated build configuration such that C API tests use the C++ linker,
+  fixing issues where the C++ standard library is not found on the
+  default C linker search paths.
+  [#14](https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/pull/14)
 
 v1.0.0-alpha.1
 --------------


### PR DESCRIPTION
The OpenAssetIO C library depends on the C++ library, which in turn depends on the C++ standard library. If the C++ standard library cannot be found in the linker's search paths, then linking will fail.

In particular, on Linux this means that libstdc++ must be discoverable. On many system layouts, including CI, this hasn't been a problem, presumably because libstdc++ happens to be in the default search paths added by `gcc`.

However, `gcc` (as opposed to `g++`) does not explicitly add the location of libstdc++ to the search paths. So on some system layouts (in particular, on my local setup using a Conda sandbox environment) linking via `gcc` will fail.

The correct thing to do seems to be to inform CMake that C++-style linking is required, so that linking is performed via `g++`, rather than `gcc`. Compilation of the C code still happens using `gcc`, but linking is performed via `g++`.