### PR TITLE
Use non-deprecated TraitsData for MediaCreation test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ name: Test
 on:
   pull_request:
 
+env:
+  # Buy some more time to use the deprecated Node 16 (needed for GLIBC
+  # version)
+  # Upgrading to the CY23 Docker images will solve this longer term. See
+  # https://github.com/OpenAssetIO/OpenAssetIO/issues/984#issuecomment-2210792734
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ v1.0.0-alpha.x
 ### Breaking Changes
 
 * Update to use non-deprecated `TraitsData` path/namespace.
-  [#13](https://github.com/OpenAssetIO/OpenAssetIO-Test-CMake/pull/13)
+  [OpenAssetIO#1311](https://github.com/OpenAssetIO/OpenAssetIO/issues/1311)
 
 ### New Features
 

--- a/src/test.mediacreation.cpp
+++ b/src/test.mediacreation.cpp
@@ -3,13 +3,13 @@
 
 // Include all headers to test they are where we expect and can be
 // compiled.
-#include <openassetio/TraitsData.hpp>
+#include <openassetio/trait/TraitsData.hpp>
 
 #include <openassetio_mediacreation/openassetio_mediacreation.hpp>
 
 int main() {
   auto trait = openassetio_mediacreation::traits::managementPolicy::ManagedTrait(
-      openassetio::TraitsData::make());
+      openassetio::trait::TraitsData::make());
 
   trait.imbue();
   return 0;


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1311. In #13 we missed an `#include` that was still using the deprecated location of the `TraitsData` type.